### PR TITLE
updated for correct pod syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Choose your installation method - CocoaPods (recommended) or source.
 
 ```ruby
 platform :ios, '7.0'
-pod 'sendgrid', '~>  0.1.0'
+pod 'SendGrid', '~>  0.2.6'
 ```
 
 Run the following in the command line:


### PR DESCRIPTION
previous pod syntax was for the wrong instance of the sendgrid library, this allows for the install to work correctly.

further incremented the sendgrid version.

commit with help from @nquinlan
