### PR TITLE
Fix Email attachments when using Swift instead of Objective C

### DIFF
--- a/Classes/SendGrid.m
+++ b/Classes/SendGrid.m
@@ -97,7 +97,7 @@ NSString * const sgEndpoint = @"api/mail.send.json";
              SendGridEmailAttachment *attachment = [email.attachments objectAtIndex:i];
              NSData *attachmentData = attachment.attachmentData;
              NSString *mimetype = attachment.mimeType;
-             NSString *filename = [NSString stringWithFormat:@"%@.%@", attachment.fileName, attachment.extension];
+             NSString *filename = [NSString stringWithFormat:@"%@.%@", attachment.fileName, attachment.fileExtension];
              NSString *name = [NSString stringWithFormat:@"files[%@]", filename];
              [formData appendPartWithFileData:attachmentData name:name fileName:filename mimeType:mimetype];
          }

--- a/Classes/SendGridEmailAttachment.h
+++ b/Classes/SendGridEmailAttachment.h
@@ -13,6 +13,6 @@
 @property (nonatomic, strong) NSData *attachmentData;
 @property (nonatomic, strong) NSString *mimeType;
 @property (nonatomic, strong) NSString *fileName;
-@property (nonatomic, strong) NSString *extension;
+@property (nonatomic, strong) NSString *fileExtension;
 
 @end


### PR DESCRIPTION
Change extension property to fileExtension since extension is a reserved keyword in Swift
